### PR TITLE
Fixed strange bug with empty response.CharacterSet

### DIFF
--- a/HttpClient.IntegrationTests/HttpClient_IntegrationTests.fs
+++ b/HttpClient.IntegrationTests/HttpClient_IntegrationTests.fs
@@ -295,8 +295,13 @@ type ``Integration tests`` ()=
 
     [<Test>]
     member x.``if a response character encoding is NOT specified, and character encoding is NOT specified in the response's content-type header, the body is read using ISO Latin 1 character encoding`` () =
-        let response = createRequest Get "http://localhost:1234/TestServer/MoonLanguageNoEncoding" |> getResponse
-        response.EntityBody.Value |> should equal "ÿ§§¿ÄÉ" // "яЏ§§їДЙ" (as encoded with windows-1251) decoded with ISO-8859-1 (Latin 1)
+        let expected = "ÿ§§¿ÄÉ" // "яЏ§§їДЙ" (as encoded with windows-1251) decoded with ISO-8859-1 (Latin 1)
+
+        let response = createRequest Get "http://localhost:1234/TestServer/MoonLanguageTextPlainNoEncoding" |> getResponse
+        response.EntityBody.Value |> should equal expected
+
+        let response = createRequest Get "http://localhost:1234/TestServer/MoonLanguageApplicationXmlNoEncoding" |> getResponse
+        response.EntityBody.Value |> should equal expected
 
     [<Test>]
     member x.``if a response character encoding is NOT specified, and the character encoding specified in the response's content-type header is invalid, an exception is thrown`` () =

--- a/HttpClient.IntegrationTests/HttpServer.fs
+++ b/HttpClient.IntegrationTests/HttpServer.fs
@@ -63,10 +63,16 @@ type FakeServer() as self =
                 response.ContentType <- "text/plain; charset=windows-1251"
                 response :> obj
 
-        self.Get.["MoonLanguageNoEncoding"] <- 
+        self.Get.["MoonLanguageTextPlainNoEncoding"] <- 
             fun _ -> 
                 let response = new EncodedResponse("яЏ§§їДЙ", "windows-1251")
                 response.ContentType <- "text/plain"
+                response :> obj
+
+        self.Get.["MoonLanguageApplicationXmlNoEncoding"] <- 
+            fun _ -> 
+                let response = new EncodedResponse("яЏ§§їДЙ", "windows-1251")
+                response.ContentType <- "application/xml"
                 response :> obj
 
         self.Get.["MoonLanguageInvalidEncoding"] <- 

--- a/HttpClient/HttpClient.fs
+++ b/HttpClient/HttpClient.fs
@@ -456,7 +456,7 @@ let private readBody encoding (response:HttpWebResponse) = async {
         match encoding with
         | None -> 
             match response.CharacterSet with
-            | null -> Encoding.GetEncoding(ISO_Latin_1)
+            | null | "" -> Encoding.GetEncoding(ISO_Latin_1)
             | responseCharset -> Encoding.GetEncoding(responseCharset |> mapEncoding)
         | Some(enc) -> Encoding.GetEncoding(enc:string)
     use responseStream = new AsyncStreamReader(response.GetResponseStream(),charset)


### PR DESCRIPTION
If Content-Type "text/plain" replace with "application/xml" then response.CharacterSet will be not null, but "" (empty string). Very, very strange HttpWebResponse behavior.
