### PR TITLE
HttpWebRequest ResponseUri is now here.

### DIFF
--- a/HttpClient.IntegrationTests/HttpClient_IntegrationTests.fs
+++ b/HttpClient.IntegrationTests/HttpClient_IntegrationTests.fs
@@ -442,6 +442,16 @@ type ``Integration tests`` ()=
     member x.``Delete method works`` () =
         createRequest Delete "http://localhost:1234/TestServer/Delete" |> getResponseCode |> should equal 200
 
+    [<Test>]
+    member x.``geResponse.ResponseUri should contain URI that responded to the request`` () =
+        // Is going to redirect to another route and return GET 200.
+        let request = 
+            createRequest Post "http://localhost:1234/TestServer/Redirect" 
+            |> withBody "hi mum" // posts need a body in Nancy
+        
+        let resp = request |> getResponse 
+        resp.StatusCode |> should equal 200
+        resp.ResponseUri.ToString() |> should equal "http://localhost:1234/TestServer/GoodStatusCode"
 
     // Nancy doesn't support Trace or Connect HTTP methods, so we can't test them easily
 

--- a/HttpClient.IntegrationTests/HttpServer.fs
+++ b/HttpClient.IntegrationTests/HttpServer.fs
@@ -1,6 +1,7 @@
 ﻿module HttpServer
 
 open Nancy
+open Nancy.Extensions
 open Nancy.Hosting.Self
 open System
 open System.Threading
@@ -157,6 +158,21 @@ type FakeServer() as self =
                     do! Async.Sleep(10000)
                 } |> Async.RunSynchronously
                 200 :> obj
+
+        /// The response to the request can be found under another URI using a GET method. 
+        /// When received in response to a POST (or PUT/DELETE), it should be assumed that the server has 
+        /// received the data and the redirect should be issued with a separate GET message.
+        /// However, some Web applications and frameworks use the 302 status code as if it were the 303.
+        /// See http://en.wikipedia.org/wiki/List_of_HTTP_status_codes.
+        self.Post.["Redirect"] <- 
+            fun _ -> 
+                //let response = "body" |> Nancy.Response.op_Implicit
+                let r = new Responses.RedirectResponse(
+                            // Use existing route with code 200.
+                            "http://localhost:1234/TestServer/GoodStatusCode",
+                            // Redirect this request using HTTP GET (303), no 302 code.
+                            Nancy.Responses.RedirectResponse.RedirectType.SeeOther) 
+                r :> obj
 
         self.Get.["Get"] <- fun _ -> 200 :> obj
         // Head method automatically handled for Get methods in Nancy

--- a/HttpClient.UnitTests/HttpClient_Tests.fs
+++ b/HttpClient.UnitTests/HttpClient_Tests.fs
@@ -21,8 +21,8 @@ let ``createRequest makes a Request with a Method and URL, and sensible defaults
     createdRequest.BodyCharacterEncoding.IsNone |> should equal true
     createdRequest.Cookies.IsNone |> should equal true
     createdRequest.CookiesEnabled |> should equal true
-    createdRequest.Headers.IsNone |> should equal true
-    createdRequest.QueryStringItems.IsNone |> should equal true
+    createdRequest.Headers.Length |> should equal 0
+    createdRequest.QueryStringItems.IsEmpty |> should equal true
     createdRequest.ResponseCharacterEncoding.IsNone |> should equal true
     createdRequest.Proxy.IsNone |> should equal true
     createdRequest.KeepAlive |> should equal true
@@ -46,13 +46,13 @@ let ``withCookiesDisabled disables cookies`` () =
 [<Test>]
 let ``withHeader adds header to the request`` () =
     (createValidRequest
-    |> withHeader (UserAgent "Mozilla/5.0 (Windows NT 6.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")).Headers.Value
+    |> withHeader (UserAgent "Mozilla/5.0 (Windows NT 6.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")).Headers
     |> should equal [ UserAgent "Mozilla/5.0 (Windows NT 6.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36" ]
 
 [<Test>]
 let ``withHeader Custom adds a custom header to the request`` () =
     (createValidRequest
-    |> withHeader (Custom { name="X-Hello-Mum"; value="Happy Birthday!"})).Headers.Value
+    |> withHeader (Custom { name="X-Hello-Mum"; value="Happy Birthday!"})).Headers
     |> should equal [ Custom { name="X-Hello-Mum"; value="Happy Birthday!"} ]
 
 [<Test>]
@@ -63,26 +63,26 @@ let ``multiple headers of different types can be added, including custom headers
         |> withHeader (Referer "ref")
         |> withHeader (Custom { name="c1"; value="v1"})
         |> withHeader (Custom { name="c2"; value="v2"})
-    createdRequest.Headers.Value |> should haveLength 4
-    createdRequest.Headers.Value |> should contain (UserAgent "ua")
-    createdRequest.Headers.Value |> should contain (Referer "ref")
-    createdRequest.Headers.Value |> should contain (Custom { name = "c1"; value = "v1" })
-    createdRequest.Headers.Value |> should contain (Custom { name = "c2"; value = "v2"})
+    createdRequest.Headers |> should haveLength 4
+    createdRequest.Headers |> should contain (UserAgent "ua")
+    createdRequest.Headers |> should contain (Referer "ref")
+    createdRequest.Headers |> should contain (Custom { name = "c1"; value = "v1" })
+    createdRequest.Headers |> should contain (Custom { name = "c2"; value = "v2"})
 
 [<Test>]
 let ``withBasicAuthentication sets the Authorization header with the username and password base-64 encoded`` () =
     let createdRequest =
         createValidRequest
         |> withBasicAuthentication "myUsername" "myPassword"
-    createdRequest.Headers |> Option.isSome |> should equal true
-    createdRequest.Headers.Value |> should contain (Authorization "Basic bXlVc2VybmFtZTpteVBhc3N3b3Jk")
+    createdRequest.Headers.Length |> should equal 1
+    createdRequest.Headers |> should contain (Authorization "Basic bXlVc2VybmFtZTpteVBhc3N3b3Jk")
 
 [<Test>]
 let ``withBasicAuthentication encodes the username and password with ISO-8859-1 before converting to base-64`` () =
     let createdRequest =
         createValidRequest
         |> withBasicAuthentication "Ãµ¶" "ÖØ" // ISO-8859-1 characters not present in ASCII
-    createdRequest.Headers.Value |> should contain (Authorization "Basic w7W2OtbY")
+    createdRequest.Headers |> should contain (Authorization "Basic w7W2OtbY")
 
 [<Test>]
 let ``If the same header is added multiple times, throws an exception`` () =
@@ -135,9 +135,9 @@ let ``withQueryString adds the query string item to the list`` () =
         createValidRequest
         |> withQueryStringItem {name="f1"; value="v1"}
         |> withQueryStringItem {name="f2"; value="v2"}
-    createdRequest.QueryStringItems.Value |> should haveLength 2
-    createdRequest.QueryStringItems.Value |> should contain {name="f1"; value="v1"}
-    createdRequest.QueryStringItems.Value |> should contain {name="f2"; value="v2"}
+    createdRequest.QueryStringItems |> should haveLength 2
+    createdRequest.QueryStringItems |> should contain {name="f1"; value="v1"}
+    createdRequest.QueryStringItems |> should contain {name="f2"; value="v2"}
 
 [<Test>]
 let ``withCookie throws an exception if cookies are disabled`` () =

--- a/HttpClient/HttpClient.fs
+++ b/HttpClient/HttpClient.fs
@@ -137,6 +137,9 @@ type Response = {
     ContentLength: int64
     Cookies: Map<string,string>
     Headers: Map<ResponseHeader,string>
+    /// A Uri that contains the URI of the Internet resource that responded to the request.
+    /// <see cref="https://msdn.microsoft.com/en-us/library/system.net.httpwebresponse.responseuri%28v=vs.110%29.aspx"/>.
+    ResponseUri : System.Uri
 }
 
 /// <summary>Creates the Request record which can be used to make an HTTP request</summary>
@@ -555,6 +558,7 @@ let getResponseAsync request = async {
         ContentLength = response.ContentLength
         Cookies = cookies
         Headers = headers
+        ResponseUri = response.ResponseUri
     }
 }
 


### PR DESCRIPTION
Uri that responded to request, useful with redirects. Location header may be empty.
- HttpServer. Post Redirect route, returns another route as Get.
- Integration tests. Call redirect and check ResponseUri.
