### PR TITLE
Various minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ TestResults/
 ehthumbs.db
 Icon?
 Thumbs.db
-AssemblyInfo.fs
 *.userprefs
 # Include Tools
 !/Tools/NUnit-2.6.3/*

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FAKE" version="3.14.0" />
-</packages>

--- a/Http.fs.sln
+++ b/Http.fs.sln
@@ -1,20 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{6DFFC726-4A59-42E2-94FA-015175A52265}"
 	ProjectSection(SolutionItems) = preProject
 		paket.dependencies = paket.dependencies
+		paket.lock = paket.lock
 	EndProjectSection
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "HttpFs.UnitTests", "HttpFs.UnitTests\HttpFs.UnitTests.fsproj", "{CCBDC979-337B-4D2F-9E64-9253083C33F8}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "HttpFs.UnitTests", "HttpFs.UnitTests\HttpFs.UnitTests.fsproj", "{CCBDC979-337B-4D2F-9E64-9253083C33F8}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "HttpFs", "HttpFs\HttpFs.fsproj", "{DC478A22-3190-46CB-A085-88014CC36957}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "HttpFs", "HttpFs\HttpFs.fsproj", "{DC478A22-3190-46CB-A085-88014CC36957}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "HttpFs.IntegrationTests", "HttpFs.IntegrationTests\HttpFs.IntegrationTests.fsproj", "{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "HttpFs.IntegrationTests", "HttpFs.IntegrationTests\HttpFs.IntegrationTests.fsproj", "{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "HttpFs.SampleApplication", "HttpFs.SampleApplication\HttpFs.SampleApplication.fsproj", "{8907FEE4-9689-4988-881C-D768AC5D5A24}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "HttpFs.SampleApplication", "HttpFs.SampleApplication\HttpFs.SampleApplication.fsproj", "{8907FEE4-9689-4988-881C-D768AC5D5A24}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DB5E6062-BB68-4ACD-987F-FCDCA7F6403E}"
 	ProjectSection(SolutionItems) = preProject
@@ -28,14 +29,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CCBDC979-337B-4D2F-9E64-9253083C33F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CCBDC979-337B-4D2F-9E64-9253083C33F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCBDC979-337B-4D2F-9E64-9253083C33F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -44,8 +37,14 @@ Global
 		{DC478A22-3190-46CB-A085-88014CC36957}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC478A22-3190-46CB-A085-88014CC36957}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC478A22-3190-46CB-A085-88014CC36957}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42D72EA7-DC60-4546-9EC3-65B3E6FAC21D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8907FEE4-9689-4988-881C-D768AC5D5A24}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HttpFs.IntegrationTests/HttpFs.IntegrationTests.fsproj
+++ b/HttpFs.IntegrationTests/HttpFs.IntegrationTests.fsproj
@@ -111,7 +111,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>
@@ -158,7 +158,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="FsPickler">
           <HintPath>..\packages\FsPickler\lib\net45\FsPickler.dll</HintPath>
@@ -169,7 +169,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Suave">
           <HintPath>..\packages\Suave\lib\net40\Suave.dll</HintPath>

--- a/HttpFs.IntegrationTests/SuaveTests.fs
+++ b/HttpFs.IntegrationTests/SuaveTests.fs
@@ -52,7 +52,7 @@ type ``Suave Integration Tests`` () =
     let config =
       { defaultConfig with
           cancellationToken = cts.Token
-          logger = Logging.Loggers.saneDefaultsFor Suave.Logging.Warn }
+          logger = Logging.Loggers.saneDefaultsFor Suave.Logging.LogLevel.Warn }
     let listening, server = startWebServerAsync config app
     Async.Start(server, cts.Token) |> ignore
     ()

--- a/HttpFs.SampleApplication/HttpFs.SampleApplication.fsproj
+++ b/HttpFs.SampleApplication/HttpFs.SampleApplication.fsproj
@@ -101,7 +101,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>

--- a/HttpFs.SamplePostApplication/HttpClient.SamplePostApplication.fsproj
+++ b/HttpFs.SamplePostApplication/HttpClient.SamplePostApplication.fsproj
@@ -93,7 +93,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>

--- a/HttpFs.UnitTests/HttpFs.UnitTests.fsproj
+++ b/HttpFs.UnitTests/HttpFs.UnitTests.fsproj
@@ -106,7 +106,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>
@@ -153,7 +153,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="FsPickler">
           <HintPath>..\packages\FsPickler\lib\net45\FsPickler.dll</HintPath>
@@ -163,14 +163,8 @@
       </ItemGroup>
     </When>
   </Choose>
-  <ItemGroup>
-    <Reference Include="Fuchu">
-      <HintPath>..\packages\Fuchu\lib\Fuchu.dll</HintPath>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Fuchu">
           <HintPath>..\packages\Fuchu-suave\lib\net40\Fuchu.dll</HintPath>
@@ -181,7 +175,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Suave">
           <HintPath>..\packages\Suave\lib\net40\Suave.dll</HintPath>
@@ -192,7 +186,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Suave.Testing">
           <HintPath>..\packages\Suave.Testing\lib\net40\Suave.Testing.dll</HintPath>

--- a/HttpFs.UnitTests/paket.references
+++ b/HttpFs.UnitTests/paket.references
@@ -1,3 +1,2 @@
 FSharp.Core
-Fuchu
 Suave.Testing

--- a/HttpFs/AssemblyInfo.fs
+++ b/HttpFs/AssemblyInfo.fs
@@ -1,0 +1,14 @@
+﻿namespace System
+open System.Reflection
+open System.Runtime.InteropServices
+
+[<assembly: AssemblyTitleAttribute("HttpFs")>]
+[<assembly: AssemblyDescriptionAttribute("An HTTP client for F#")>]
+[<assembly: GuidAttribute("4ead3524-8220-4f0b-b77d-edd088597fcf")>]
+[<assembly: AssemblyProductAttribute("Http.fs")>]
+[<assembly: AssemblyVersionAttribute("2.0.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.0.0")>]
+do ()
+
+module internal AssemblyVersionInformation =
+    let [<Literal>] Version = "2.0.0"

--- a/HttpFs/HttpFs.fsproj
+++ b/HttpFs/HttpFs.fsproj
@@ -93,7 +93,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ open System
 open System.Text
 
 let request =
-    createRequest Post "https://example.com"
+    createRequest Post <| Uri("https://example.com")
     |> withQueryStringItem "search" "jeebus"
     |> withBasicAuthentication "myUsername" "myPassword" // UTF8-encoded
     |> withHeader (UserAgent "Chrome or summat")

--- a/build.fsx
+++ b/build.fsx
@@ -102,8 +102,8 @@ Target "Copy Release Files" (fun _ ->
 )
 
 // note to self - call like this: 
-// packages/FAKE/tools/fake.exe build.fsx nuget-version=1.1.0 nuget-api-key=(my api key) nuget-release-notes="latest release"
-Target "Upload to NuGet" (fun _ ->
+// .\build.bat nuget-version=1.1.0 nuget-api-key=(my api key) nuget-release-notes="latest release"
+Target "NuGetPackage" (fun _ ->
     // Copy the dll into the right place
     CopyFiles 
         (releaseDir + "NuGet/lib/net45")
@@ -137,11 +137,14 @@ Target "Upload to NuGet" (fun _ ->
   @files@
 </package>""")
 
+    let description = "A gloriously functional HTTP client library for F#!"
+    
     // Create and upload package
     NuGet (fun n ->
         {n with
             Authors = ["Grant Crofton"]
-            Summary = "A gloriously functional HTTP client library for F#!"
+            Summary = description
+            Description = description
             OutputPath = nuGetDir
             WorkingDir = nuGetDir
             Project = "Http.fs"
@@ -149,7 +152,7 @@ Target "Upload to NuGet" (fun _ ->
             AccessKey = getBuildParam "nuget-api-key"
             ReleaseNotes = getBuildParam "nuget-release-notes"
             PublishTrials = 3
-            Publish = bool.Parse(getBuildParamOrDefault "nuget-publish" "true")
+            Publish = bool.Parse(getBuildParamOrDefault "nuget-publish" "false")
             ToolPath = FullName "./packages/NuGet.CommandLine/tools/NuGet.exe"
             Files =
                 [ "lib\\net45\\*.dll", Some "lib\\net45", None
@@ -172,10 +175,8 @@ Target "All" (fun _ ->
     ==> "BuildUnitTests" <=> "BuildIntegrationTests" <=> "BuildSampleApplication"
     ==> "Run Unit Tests" <=> "Run Integration Tests"
     ==> "Copy Release Files"
-    =?> ("Upload to NuGet", // run this if all params secified
-        hasBuildParam "nuget-version" && 
-        hasBuildParam "nuget-api-key" && 
-        hasBuildParam "nuget-release-notes")
+    =?> ("NuGetPackage", // run this if all params secified
+        hasBuildParam "nuget-version")
     ==> "All"
 
 // start build

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,7 +3,6 @@ source https://www.nuget.org/api/v2
 nuget FAKE
 nuget FSharp.Core
 nuget FsUnit ~> 1.2
-nuget Fuchu
 nuget Nancy ~> 0.22
 nuget Nancy.Hosting.Self ~> 0.22
 nuget NUnit ~> 2.6.3

--- a/paket.lock
+++ b/paket.lock
@@ -1,12 +1,11 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://nuget.org/api/v2
   specs:
     FAKE (3.33.0)
     FSharp.Core (3.1.2.1)
     FsPickler (1.2.0)
     FsUnit (1.3.0.1)
       NUnit (>= 2.6.3)
-    Fuchu (0.6.0.0)
     Fuchu-suave (0.6.1)
       FSharp.Core (>= 3.1.2.1)
     Nancy (0.23.2)


### PR DESCRIPTION
- Adds AssemblyInfo.fs to source control (fixing #86)
- fixes the warning that causes build error on the build server due to treat-warnings-as-errors (I don't get it locally, maybe the build server is using F# 4 or something)
- Removes vanilla Fuchu, because Suave.Testing uses its own Fuchu-suave and using both creates lots of warnings
- removes unused (I think) .nuget folder
- fixes error about missing Description when building nuget package
- nuget step defaults to publish false, not publish true, and doesn't require an API key if testing locally
