### PR TITLE
Disable Shadow Copy for Integration Tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -75,7 +75,7 @@ end
 
 namespace :tests do
   task :integration do
-    system 'packages/NUnit.Runners/tools/nunit-console.exe', %W|
+    system 'packages/NUnit.Runners/tools/nunit-console.exe', '--noshadow', %W|
            HttpFs.IntegrationTests/bin/#{Configuration}/HttpFs.IntegrationTests.dll|,
            clr_command: true
   end


### PR DESCRIPTION
This should fix the AppVeyor issue for Windows builds.
