### PR TITLE
Changed from use of HttpWebRequest to HttpClient

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -2,9 +2,15 @@
   <!-- Prevent dotnet template engine to parse this file -->
   <!--/-:cnd:noEmit-->
   <PropertyGroup>
+    <!-- make MSBuild track this file for incremental builds. -->
+    <!-- ref https://blogs.msdn.microsoft.com/msbuild/2005/09/26/how-to-ensure-changes-to-a-custom-target-file-prompt-a-rebuild/ -->
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <!-- Mark that this target file has been loaded.  -->
     <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
     <PaketToolsPath>$(MSBuildThisFileDirectory)</PaketToolsPath>
+    <PaketRootPath>$(MSBuildThisFileDirectory)..\</PaketRootPath>
+    <PaketRestoreCacheFile>$(PaketRootPath)paket-files\paket.restore.cached</PaketRestoreCacheFile>
+    <PaketLockFilePath>$(PaketRootPath)paket.lock</PaketLockFilePath>
     <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
     <!-- Paket command -->
@@ -16,29 +22,79 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-    
+
     <!-- Disable automagic references for F# dotnet sdk -->
     <!-- This will not do anything for other project types -->
     <!-- see https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1032-fsharp-in-dotnet-sdk.md -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>  
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 
   <Target Name="PaketRestore" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
 
-    <Exec Command='$(PaketBootStrapperCommand) ' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework $(TargetFramework)' Condition="$(TargetFramework) != ''" ContinueOnError="false" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFrameworks)"' Condition="$(TargetFramework) == ''" ContinueOnError="false" />
-
+    <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
-      <PaketReferencesFilePath>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references</PaketReferencesFilePath>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
     </PropertyGroup>
 
-    <ReadLinesFromFile File="$(PaketReferencesFilePath)" >
+    <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
+      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
+      <PaketRestoreLockFileHash>$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <!-- Do a global restore if required -->
+    <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+
+    <!-- Step 2 Detect project specific changes -->
+    <PropertyGroup>
+      <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
+      <!-- MyProject.fsproj.paket.references has the highest precedence -->
+      <PaketOriginalReferencesFilePath>$(MSBuildProjectFullPath).paket.references</PaketOriginalReferencesFilePath>
+      <!-- MyProject.paket.references -->
+      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
+      <!-- paket.references -->
+      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
+      <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
+    </PropertyGroup>
+
+    <!-- Step 2 a Detect changes in references file -->
+    <PropertyGroup Condition="Exists('$(PaketOriginalReferencesFilePath)') AND Exists('$(PaketReferencesCachedFilePath)') ">
+      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketReferencesCachedFilePath)'))</PaketRestoreCachedHash>
+      <PaketRestoreReferencesFileHash>$([System.IO.File]::ReadAllText('$(PaketOriginalReferencesFilePath)'))</PaketRestoreReferencesFileHash>
+      <PaketRestoreRequiredReason>references-file</PaketRestoreRequiredReason>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreReferencesFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!Exists('$(PaketOriginalReferencesFilePath)') AND !Exists('$(PaketReferencesCachedFilePath)') ">
+      <!-- If both don't exist there is nothing to do. -->
+      <PaketRestoreRequired>false</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
+    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
+    </PropertyGroup>
+
+    <!-- Step 3 Restore project specific stuff if required -->
+    <Warning Condition=" '$(PaketRestoreRequired)' == 'true' "  Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+
+    <!-- This shouldn't actually happen, but just to be sure. -->
+    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' " Text="A paket file for the framework '$(TargetFramework)' is missing. Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+
+    <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
+    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition=" '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
@@ -80,7 +136,7 @@
 
   <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
-      <PaketReferencesFilePath>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references</PaketReferencesFilePath>
+      <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
       <UseNewPack>false</UseNewPack>
       <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
@@ -90,7 +146,7 @@
       <_NuspecFiles Include="$(BaseIntermediateOutputPath)*.nuspec"/>
     </ItemGroup>
 
-    <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" references-file "$(PaketReferencesFilePath)" ' Condition="@(_NuspecFiles) != ''" />
+    <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />

--- a/HttpFs.IntegrationTests/HttpFs.IntegrationTests.fsproj
+++ b/HttpFs.IntegrationTests/HttpFs.IntegrationTests.fsproj
@@ -21,5 +21,11 @@
   <ItemGroup>
     <ProjectReference Include="..\HttpFs\HttpFs.fsproj" />
   </ItemGroup>  
+  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+    <Reference Include="System.Net.Http">
+      <HintPath>..\..\packages\System.Net.Http\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/HttpFs.IntegrationTests/HttpServer.fs
+++ b/HttpFs.IntegrationTests/HttpServer.fs
@@ -22,11 +22,11 @@ let uriFor path =
 
 let app =
   choose [
-    Filters.GET >=> choose [
-      Filters.path "/RecordRequest" >=> request (fun r ->
-        recordedRequest <- Some r
-        Successful.OK "")
+    Filters.path "/RecordRequest" >=> request (fun r ->
+      recordedRequest <- Some r
+      Successful.OK "")
 
+    Filters.GET >=> choose [
       Filters.path "/GoodStatusCode" >=> Successful.OK ""
 
       Filters.path "/BadStatusCode" >=> RequestErrors.UNAUTHORIZED ""

--- a/HttpFs.IntegrationTests/HttpServer.fs
+++ b/HttpFs.IntegrationTests/HttpServer.fs
@@ -145,6 +145,22 @@ let app =
           |> List.map (fun f -> f.fileName)
           |> String.concat "\n"
           |> Successful.OK)
+
+        Filters.path "/multipart" >=> request (fun r ->
+          let formStr =
+            r.multiPartFields
+            |> List.map (fun (x, y) -> sprintf "%s: %s" x y)
+            |> String.concat "\n"
+
+          let filesStr =
+            r.files
+            |> List.map (fun x -> x.fileName)
+            |> String.concat "\n"
+
+          [ formStr; filesStr ]
+          |> String.concat "\n"
+          |> Successful.OK)
+
     ]
 
     Filters.HEAD >=> Filters.path "/Head" >=> Successful.OK ""

--- a/HttpFs.IntegrationTests/Tests.fs
+++ b/HttpFs.IntegrationTests/Tests.fs
@@ -75,7 +75,6 @@ let recorded =
 
     testCase "all of the manually-set request headers get sent to the server" <| fun _ ->
       Request.create Post (uriFor "/RecordRequest")
-      // |> Request.keepAlive false
       |> Request.setHeader (Accept "application/xml,text/html;q=0.3")
       |> Request.setHeader (AcceptCharset "utf-8, utf-16;q=0.5")
       |> Request.setHeader (AcceptDatetime "Thu, 31 May 2007 20:35:00 GMT")
@@ -316,7 +315,6 @@ let tests =
         |> getResponse
         |> run
 
-      printfn "Cookies: %A" response.cookies
       Expect.equal response.statusCode 200 "statusCode should be equal"
       Expect.equal (response.cookies.ContainsKey "cookie1") false "cookies should not contain key"
 

--- a/HttpFs.IntegrationTests/Tests.fs
+++ b/HttpFs.IntegrationTests/Tests.fs
@@ -435,7 +435,7 @@ let tests =
       for fileName in [ "file1.txt"; "file2.gif" ] do
         Expect.stringContains response fileName "response should contain filename"
 
-    ftestCase "multipart/mixed returns form values" <| fun _ ->
+    testCase "multipart/mixed returns form values" <| fun _ ->
       let firstCt, secondCt, thirdCt, fourthCt, fifthCt, fileContents =
         ContentType.parse "text/plain" |> Option.get,
         ContentType.parse "text/plain" |> Option.get,

--- a/HttpFs.IntegrationTests/paket.references
+++ b/HttpFs.IntegrationTests/paket.references
@@ -3,3 +3,4 @@ FSharp.Core
 Hopac
 Suave
 System.Text.Encoding.CodePages
+System.Net.Http

--- a/HttpFs.SampleApplication/Program.fs
+++ b/HttpFs.SampleApplication/Program.fs
@@ -66,8 +66,6 @@ let complexRequest() = job {
   let request =
     Request.create Get (Uri "http://www.google.com/search")
     |> Request.queryStringItem "q" "gibbons"
-    // |> Request.autoDecompression DecompressionScheme.GZip
-    // |> Request.autoFollowRedirectsDisabled
     |> Request.cookie (Cookie.create("ignoreMe", "hi mum"))
     |> Request.setHeader (Accept "text/html")
     |> Request.setHeader (UserAgent "Mozilla/5.0 (Windows NT 6.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")

--- a/HttpFs.SampleApplication/Program.fs
+++ b/HttpFs.SampleApplication/Program.fs
@@ -66,8 +66,8 @@ let complexRequest() = job {
   let request =
     Request.create Get (Uri "http://www.google.com/search")
     |> Request.queryStringItem "q" "gibbons"
-    |> Request.autoDecompression DecompressionScheme.GZip
-    |> Request.autoFollowRedirectsDisabled
+    // |> Request.autoDecompression DecompressionScheme.GZip
+    // |> Request.autoFollowRedirectsDisabled
     |> Request.cookie (Cookie.create("ignoreMe", "hi mum"))
     |> Request.setHeader (Accept "text/html")
     |> Request.setHeader (UserAgent "Mozilla/5.0 (Windows NT 6.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")

--- a/HttpFs.UnitTests/Api.fs
+++ b/HttpFs.UnitTests/Api.fs
@@ -17,8 +17,6 @@ let api =
       let r = Request.createUrl Get "http://www.google.com"
       Expect.equal (r.url.ToString()) "http://www.google.com/" "has same url"
       Expect.equal r.method Get "has get method"
-      // Expect.equal r.autoDecompression DecompressionScheme.None "has no decompression scheme"
-      // Expect.isTrue r.autoFollowRedirects "should follow redirects"
       Expect.equal r.body (BodyRaw [||]) "has empty body"
       Expect.equal r.bodyCharacterEncoding Encoding.UTF8 "has UTF8 body character encoding"
       Expect.isEmpty r.cookies "has no cookies"
@@ -27,15 +25,6 @@ let api =
       Expect.isEmpty r.queryStringItems "has no query string"
       Expect.isNone r.responseCharacterEncoding "has no response char encoding"
       Expect.isNone r.proxy "has no proxy configured"
-      // Expect.isTrue r.keepAlive "user keep-alive"
-
-    // testCase "withAutoDecompression enables the specified decompression methods" <| fun _ ->
-    //   let createdRequest =
-    //     validRequest
-    //     |> autoDecompression (DecompressionScheme.Deflate ||| DecompressionScheme.GZip)
-
-    //   Expect.equal DecompressionScheme.Deflate (createdRequest.autoDecompression &&& DecompressionScheme.Deflate) "deflate"
-    //   Expect.equal DecompressionScheme.GZip (createdRequest.autoDecompression &&& DecompressionScheme.GZip) "gzip"
 
     testCase "withClient uses specified client" <| fun _ ->
       let client = new HttpClient()
@@ -126,9 +115,6 @@ let api =
       Expect.canPick c (Cookie.create("c1", "v1")) "should have first cookie"
       Expect.canPick c (Cookie.create("c2", "v2")) "should have second cookie"
 
-    // testCase "withAutoFollowRedirectsDisabled turns auto-follow off" <| fun _ ->
-    //   Expect.isFalse (validRequest |> autoFollowRedirectsDisabled).autoFollowRedirects "should be disabled"
-
     testCase "withResponseCharacterEncoding sets the response character encoding" <| fun _ ->
       let createdRequest =
         createUrl Get "http://www.google.com/"
@@ -168,7 +154,4 @@ let api =
         |> proxy { Address = ""; Port = 0; Credentials = Credentials.None }
 
       Expect.equal request.proxy.Value.Credentials Credentials.None "credentials should be none"
-
-    // testCase "withKeepAlive sets KeepAlive" <| fun _ ->
-    //   Expect.isFalse (validRequest |> keepAlive false).keepAlive "keepAlive should be false"
   ]

--- a/HttpFs.UnitTests/Api.fs
+++ b/HttpFs.UnitTests/Api.fs
@@ -1,6 +1,7 @@
 ﻿module HttpFs.Tests.Api
 
 open System
+open System.Net.Http
 open System.Text
 open Expecto
 open HttpFs.Client
@@ -16,8 +17,8 @@ let api =
       let r = Request.createUrl Get "http://www.google.com"
       Expect.equal (r.url.ToString()) "http://www.google.com/" "has same url"
       Expect.equal r.method Get "has get method"
-      Expect.equal r.autoDecompression DecompressionScheme.None "has no decompression scheme"
-      Expect.isTrue r.autoFollowRedirects "should follow redirects"
+      // Expect.equal r.autoDecompression DecompressionScheme.None "has no decompression scheme"
+      // Expect.isTrue r.autoFollowRedirects "should follow redirects"
       Expect.equal r.body (BodyRaw [||]) "has empty body"
       Expect.equal r.bodyCharacterEncoding Encoding.UTF8 "has UTF8 body character encoding"
       Expect.isEmpty r.cookies "has no cookies"
@@ -26,15 +27,20 @@ let api =
       Expect.isEmpty r.queryStringItems "has no query string"
       Expect.isNone r.responseCharacterEncoding "has no response char encoding"
       Expect.isNone r.proxy "has no proxy configured"
-      Expect.isTrue r.keepAlive "user keep-alive"
+      // Expect.isTrue r.keepAlive "user keep-alive"
 
-    testCase "withAutoDecompression enables the specified decompression methods" <| fun _ ->
-      let createdRequest =
-        validRequest
-        |> autoDecompression (DecompressionScheme.Deflate ||| DecompressionScheme.GZip)
+    // testCase "withAutoDecompression enables the specified decompression methods" <| fun _ ->
+    //   let createdRequest =
+    //     validRequest
+    //     |> autoDecompression (DecompressionScheme.Deflate ||| DecompressionScheme.GZip)
 
-      Expect.equal DecompressionScheme.Deflate (createdRequest.autoDecompression &&& DecompressionScheme.Deflate) "deflate"
-      Expect.equal DecompressionScheme.GZip (createdRequest.autoDecompression &&& DecompressionScheme.GZip) "gzip"
+    //   Expect.equal DecompressionScheme.Deflate (createdRequest.autoDecompression &&& DecompressionScheme.Deflate) "deflate"
+    //   Expect.equal DecompressionScheme.GZip (createdRequest.autoDecompression &&& DecompressionScheme.GZip) "gzip"
+
+    testCase "withClient uses specified client" <| fun _ ->
+      let client = new HttpClient()
+      let request = Request.createWithClient client Get ValidUri
+      Expect.equal client request.httpClient "httpClient should be set"
 
     testCase "withCookiesDisabled disables cookies" <| fun _ ->
       Expect.isFalse (validRequest |> Request.cookiesDisabled).cookiesEnabled "should disable cookies"
@@ -120,8 +126,8 @@ let api =
       Expect.canPick c (Cookie.create("c1", "v1")) "should have first cookie"
       Expect.canPick c (Cookie.create("c2", "v2")) "should have second cookie"
 
-    testCase "withAutoFollowRedirectsDisabled turns auto-follow off" <| fun _ ->
-      Expect.isFalse (validRequest |> autoFollowRedirectsDisabled).autoFollowRedirects "should be disabled"
+    // testCase "withAutoFollowRedirectsDisabled turns auto-follow off" <| fun _ ->
+    //   Expect.isFalse (validRequest |> autoFollowRedirectsDisabled).autoFollowRedirects "should be disabled"
 
     testCase "withResponseCharacterEncoding sets the response character encoding" <| fun _ ->
       let createdRequest =
@@ -163,6 +169,6 @@ let api =
 
       Expect.equal request.proxy.Value.Credentials Credentials.None "credentials should be none"
 
-    testCase "withKeepAlive sets KeepAlive" <| fun _ ->
-      Expect.isFalse (validRequest |> keepAlive false).keepAlive "keepAlive should be false"
+    // testCase "withKeepAlive sets KeepAlive" <| fun _ ->
+    //   Expect.isFalse (validRequest |> keepAlive false).keepAlive "keepAlive should be false"
   ]

--- a/HttpFs.UnitTests/HttpFs.UnitTests.fsproj
+++ b/HttpFs.UnitTests/HttpFs.UnitTests.fsproj
@@ -14,7 +14,9 @@
     <Compile Include="RequestBody.fs" />
     <Compile Include="SendingStreams.fs" />
     <Compile Include="Program.fs" />
-    <None Include="app.config" />
+    <None Include="app.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="paket.references" />
     <None Include="pix.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/HttpFs.UnitTests/RequestBody.fs
+++ b/HttpFs.UnitTests/RequestBody.fs
@@ -140,7 +140,7 @@ let bodyFormatting =
       let subject = bytes |> utf8.GetString
 
       let expectedBoundary1 = "BgOE:fCUQGnYfKwGMnxoyfwVMbRzZF"
-      let expectedBoundary2 = "TYHqj_uqWKBHGwtogjeH-_oyB_JTR/"
+      let expectedBoundary2 = "TYHqj+uqWKBHGwtogjeH-+oyB+JTR/"
 
       let expected =
           [ sprintf "--%s" expectedBoundary1

--- a/HttpFs.UnitTests/RequestBody.fs
+++ b/HttpFs.UnitTests/RequestBody.fs
@@ -105,7 +105,6 @@ let bodyFormatting =
                        ""
                        "Hello World"
                        sprintf "--%s--" expectedBoundary
-                       ""
                        "" ]
                      |> String.concat "\r\n"
 
@@ -185,7 +184,6 @@ let bodyFormatting =
             "SGVsbG8gV29ybGQ="
             sprintf "--%s--" expectedBoundary2
             sprintf "--%s--" expectedBoundary1
-            ""
             "" ]
           |> String.concat "\r\n"
       
@@ -229,7 +227,7 @@ let internals =
   testCase "http web request url" <| fun _ ->
     use ms = new IO.MemoryStream()
     let hfsReq = Request.create Get (Uri "http://localhost/") |> Request.queryStringItem "a" "1"
-    let reqMessage, _ = DotNetWrapper.toHttpRequestMessage HttpFsState.empty ms hfsReq
+    let reqMessage = DotNetWrapper.toHttpRequestMessage HttpFsState.empty ms hfsReq |> Hopac.run
     Expect.equal (string reqMessage.RequestUri) "http://localhost/?a=1" "uri should be equal"
 
 [<Tests>]

--- a/HttpFs.UnitTests/SendingStreams.fs
+++ b/HttpFs.UnitTests/SendingStreams.fs
@@ -38,7 +38,7 @@ let pathOf relativePath =
 [<Tests>]
 let tests =
   let runWithConfig = runWith defaultConfig
-  let uriFor (res : string) = Uri (sprintf "http://localhost.fiddler:8080/%s" (res.TrimStart('/')))
+  let uriFor (res : string) = Uri (sprintf "http://localhost:8080/%s" (res.TrimStart('/')))
   let request method res = Request.create ``method`` (uriFor res)
 
   testCase "can send/receive" <| fun _ ->

--- a/HttpFs.UnitTests/SendingStreams.fs
+++ b/HttpFs.UnitTests/SendingStreams.fs
@@ -26,6 +26,7 @@ let app =
                   //printfn "||| in suave, handing over to sendFile, file %s len %d"
                   //        file.tempFilePath (FileInfo(file.tempFilePath).Length)
                   Files.sendFile file.tempFilePath false)
+          
           NOT_FOUND "Nope."
       ]
     ]
@@ -38,7 +39,7 @@ let pathOf relativePath =
 let tests =
   let runWithConfig = runWith defaultConfig
   let uriFor (res : string) = Uri (sprintf "http://localhost:8080/%s" (res.TrimStart('/')))
-  let request method res = Request.create ``method`` (uriFor res) |> Request.keepAlive false
+  let request method res = Request.create ``method`` (uriFor res)
 
   testCase "can send/receive" <| fun _ ->
     job {

--- a/HttpFs.UnitTests/SendingStreams.fs
+++ b/HttpFs.UnitTests/SendingStreams.fs
@@ -38,10 +38,10 @@ let pathOf relativePath =
 [<Tests>]
 let tests =
   let runWithConfig = runWith defaultConfig
-  let uriFor (res : string) = Uri (sprintf "http://localhost:8080/%s" (res.TrimStart('/')))
+  let uriFor (res : string) = Uri (sprintf "http://localhost.fiddler:8080/%s" (res.TrimStart('/')))
   let request method res = Request.create ``method`` (uriFor res)
 
-  testCase "can send/receive" <| fun _ ->
+  ftestCase "can send/receive" <| fun _ ->
     job {
       let ctx = runWithConfig app
       try
@@ -51,11 +51,12 @@ let tests =
           
           use ms = new MemoryStream()
           //printfn "--- get response"
-          use! resp =
+          let req =
             request method "gifs/echo"
             |> Request.body (BodyForm [ FormFile ("img", file) ])
             |> Request.setHeader (Custom ("Access-Code", "Super-Secret"))
-            |> getResponse
+
+          use! resp = req |> getResponse
 
           do! Job.awaitUnitTask (resp.body.CopyToAsync ms)
 

--- a/HttpFs.UnitTests/SendingStreams.fs
+++ b/HttpFs.UnitTests/SendingStreams.fs
@@ -51,12 +51,11 @@ let tests =
           
           use ms = new MemoryStream()
           //printfn "--- get response"
-          let req =
+          use! resp =
             request method "gifs/echo"
             |> Request.body (BodyForm [ FormFile ("img", file) ])
             |> Request.setHeader (Custom ("Access-Code", "Super-Secret"))
-
-          use! resp = req |> getResponse
+            |> getResponse
 
           do! Job.awaitUnitTask (resp.body.CopyToAsync ms)
 

--- a/HttpFs.UnitTests/SendingStreams.fs
+++ b/HttpFs.UnitTests/SendingStreams.fs
@@ -41,7 +41,7 @@ let tests =
   let uriFor (res : string) = Uri (sprintf "http://localhost.fiddler:8080/%s" (res.TrimStart('/')))
   let request method res = Request.create ``method`` (uriFor res)
 
-  ftestCase "can send/receive" <| fun _ ->
+  testCase "can send/receive" <| fun _ ->
     job {
       let ctx = runWithConfig app
       try

--- a/HttpFs.UnitTests/app.config
+++ b/HttpFs.UnitTests/app.config
@@ -1,8 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
- <system.net>
-  <defaultProxy>
-   <proxy bypassonlocal="false" usesystemdefault="true" />
-  </defaultProxy>
- </system.net>
 </configuration>

--- a/HttpFs.UnitTests/app.config
+++ b/HttpFs.UnitTests/app.config
@@ -1,3 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+ <system.net>
+  <defaultProxy>
+   <proxy bypassonlocal="false" usesystemdefault="true" />
+  </defaultProxy>
+ </system.net>
 </configuration>

--- a/HttpFs/HttpFs.fs
+++ b/HttpFs/HttpFs.fs
@@ -473,7 +473,7 @@ module Client =
       |> Authorization
 
     let generateBoundary =
-      let boundaryChars = "abcdefghijklmnopqrstuvwxyz_-/':ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      let boundaryChars = "abcdefghiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\\()+,-./:=?"
       let boundaryLen = 30
       fun clientState ->
           let rnd = clientState.random

--- a/HttpFs/HttpFs.fs
+++ b/HttpFs/HttpFs.fs
@@ -739,7 +739,8 @@ module Client =
                 | AcceptLanguage value             -> add "Accept-Language" value
                 | Authorization value              -> add "Authorization" value
                 | RequestHeader.Connection value   -> add "Connection" value
-                | RequestHeader.ContentMD5 value   -> addContent (fun c -> c.Headers.Add("Content-MD5", value))
+                | RequestHeader.ContentMD5 value   -> // a mono bug results in "System.Byte[]" getting sent in the content-md5 header if added to the headers manually....
+                                                      addContent (fun c -> c.Headers.ContentMD5 <- Encoding.UTF8.GetBytes(value))
                 | RequestHeader.ContentType value  -> addContent (fun c ->
                                                         c.Headers.Remove("Content-Type") |> ignore
                                                         c.Headers.TryAddWithoutValidation("Content-Type", value.ToString()) |> ignore)

--- a/HttpFs/HttpFs.fs
+++ b/HttpFs/HttpFs.fs
@@ -473,7 +473,7 @@ module Client =
       |> Authorization
 
     let generateBoundary =
-      let boundaryChars = "abcdefghiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\\()+,-./:=?"
+      let boundaryChars = "abcdefghijklmnopqrstuvwxyz+-/':ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       let boundaryLen = 30
       fun clientState ->
           let rnd = clientState.random

--- a/HttpFs/HttpFs.fsproj
+++ b/HttpFs/HttpFs.fsproj
@@ -28,5 +28,8 @@
     <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="HttpFs.fs" />
   </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net45'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/HttpFs/paket.template
+++ b/HttpFs/paket.template
@@ -9,6 +9,7 @@ dependencies
   framework: net45
     FSharp.Core >= LOCKEDVERSION
     Hopac >= LOCKEDVERSION
+    System.Net.Http >= LOCKEDVERSION
   framework: netstandard2.0
     FSharp.Core >= LOCKEDVERSION
     Hopac >= LOCKEDVERSION

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -9,6 +9,7 @@ nuget Http.fs ~> 4
 nuget NuGet.CommandLine
 nuget OpenCover ~> 4
 nuget Suave ~> 2
+nuget System.Net.Http ~> 4
 nuget System.Text.Encoding.CodePages ~> 4
 
 github haf/YoLo YoLo.fs


### PR DESCRIPTION
Resolves: https://github.com/haf/Http.fs/issues/132

 - Swaps out the use of HttpWebRequest to use HttpClient.
 - Big performance improvement on .NET Core from HttpWebRequest, brings this back up to the expected performance.
 - Shares a `defaultHttpClient` between all requests. This is the major difference between HttpWebRequest and HttpClient, it allows Keep-Alive to work correctly on .NET Core instead of "leaking" TCP connections.

The reason this is in WIP is that there are breaking changes and cleanup needs to be done. I've commented out surface area which there is not an easy way to "map" to HttpClient, or made significant changes from the original. HttpClient moves a lot of settings into HttpMessageHandler, which is instantiated once and shared across requests. 