### PR TITLE
Added autoFollowRedirectsDisabled for backward compatibility

### DIFF
--- a/HttpFs/HttpFs.fs
+++ b/HttpFs/HttpFs.fs
@@ -631,7 +631,7 @@ module Client =
 
   module internal DotNetWrapper =
     open System.Collections.Generic
-    let defaultHttpClient =
+    let defaultHttpClient allowAutoRedirect =
       // the handler cannot be changed after the first request (you get an exception).
       // kept internal
 
@@ -639,6 +639,7 @@ module Client =
       // this stops it from stripping "Cookie" headers we set out of requests and will stop
       // cookies being implicitly shared across requests
       let handler = new HttpClientHandler(UseCookies = false)
+      handler.AllowAutoRedirect <- allowAutoRedirect
       let client = new HttpClient(handler)
       client.DefaultRequestHeaders.Clear()
       client
@@ -962,7 +963,7 @@ module Client =
         cookies                   = Map.empty
         responseCharacterEncoding = None
         proxy                     = None
-        httpClient                = defaultHttpClient }
+        httpClient                = defaultHttpClient true }
 
     let createWithClient client method url =
       { create method url with httpClient = client }
@@ -987,6 +988,10 @@ module Client =
     /// Disables cookies, which are enabled by default
     let cookiesDisabled request =
       { request with cookiesEnabled = false }
+    
+    /// Disables automatic following of redirects, which is enabled by default
+    let autoFollowRedirectsDisabled request =
+      { request with httpClient = defaultHttpClient false }
 
     /// Adds a header, defined as a RequestHeader
     /// The current implementation doesn't allow you to add a single header multiple

--- a/HttpFs/HttpFs.fs
+++ b/HttpFs/HttpFs.fs
@@ -631,7 +631,7 @@ module Client =
 
   module internal DotNetWrapper =
     open System.Collections.Generic
-    let defaultHttpClient allowAutoRedirect =
+    let createHttpClient allowAutoRedirect =
       // the handler cannot be changed after the first request (you get an exception).
       // kept internal
 
@@ -643,6 +643,11 @@ module Client =
       let client = new HttpClient(handler)
       client.DefaultRequestHeaders.Clear()
       client
+    
+    //HttpClient with autoRedirect enabled by default
+    let defaultHttpClient = createHttpClient true
+    //HttpClient with autoRedirect disabled manually
+    let noRedirectHttpClient = createHttpClient false
 
     /// Sets headers on HttpRequestMessage.
     /// Mutates HttpRequestMessage.
@@ -963,7 +968,7 @@ module Client =
         cookies                   = Map.empty
         responseCharacterEncoding = None
         proxy                     = None
-        httpClient                = defaultHttpClient true }
+        httpClient                = defaultHttpClient }
 
     let createWithClient client method url =
       { create method url with httpClient = client }
@@ -991,7 +996,7 @@ module Client =
     
     /// Disables automatic following of redirects, which is enabled by default
     let disableAutoFollowRedirects request =
-      { request with httpClient = defaultHttpClient false }
+      { request with httpClient = noRedirectHttpClient }
 
     /// Adds a header, defined as a RequestHeader
     /// The current implementation doesn't allow you to add a single header multiple

--- a/HttpFs/HttpFs.fs
+++ b/HttpFs/HttpFs.fs
@@ -990,7 +990,7 @@ module Client =
       { request with cookiesEnabled = false }
     
     /// Disables automatic following of redirects, which is enabled by default
-    let autoFollowRedirectsDisabled request =
+    let disableAutoFollowRedirects request =
       { request with httpClient = defaultHttpClient false }
 
     /// Adds a header, defined as a RequestHeader


### PR DESCRIPTION
This one is bugging me, I use this a lot and having to declare a new HttpClient to disable a redirect adds to much clutter.

What do you think?