### PR TITLE
More support for reading SSE streams

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -23,6 +23,9 @@
     <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
     <PaketCommand Condition=" '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
 
+    <!-- no extension is a shell script -->
+    <PaketCommand Condition=" '$(_PaketExeExtension)' == '' ">"$(PaketExePath)"</PaketCommand>
+
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
@@ -40,21 +43,21 @@
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <NoWarn>$(NoWarn);NU1603</NoWarn>
+      <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
     </PropertyGroup>
 
     <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
     <PropertyGroup>
-        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
-        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketRestoreCacheFile)" | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketLockFilePath)" | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
     </PropertyGroup>
 
     <!-- If shasum and awk exist get the hashes -->
-    <Exec Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
-        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
     </Exec>
-    <Exec Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
-        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
     </Exec>
 
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
@@ -66,11 +69,18 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
 
+
     <!-- Do a global restore if required -->
     <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
-    <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
     <!-- Step 2 Detect project specific changes -->
+    <ItemGroup>
+      <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
+      <MyTargetFrameworks Condition="'@(TargetFrameworks)' != '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
+      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
+    </ItemGroup>
     <PropertyGroup>
       <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
       <!-- MyProject.fsproj.paket.references has the highest precedence -->
@@ -79,7 +89,10 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
+      
       <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
     </PropertyGroup>
@@ -98,24 +111,29 @@
     </PropertyGroup>
 
     <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
-    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
+    <PropertyGroup Condition=" '$(DoAllResolvedFilesExist)' != 'true' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)' or '$(TargetFrameworks)'</PaketRestoreRequiredReason>
     </PropertyGroup>
 
     <!-- Step 3 Restore project specific stuff if required -->
     <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
-    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+    <PropertyGroup>
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
+    </PropertyGroup>
+    <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
+    <ReadLinesFromFile Condition="'@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" ><!--Condition="Exists('%(PaketResolvedFilePaths.Identity)')"-->
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition=" '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
@@ -124,6 +142,7 @@
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
         <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
+        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
       </PackageReference>
     </ItemGroup>
 
@@ -145,9 +164,10 @@
       </DotNetCliToolReference>
     </ItemGroup>
 
+    <!-- Disabled for now until we know what to do with runtime deps - https://github.com/fsprojects/Paket/issues/2964
     <PropertyGroup>
       <RestoreConfigFile>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
-    </PropertyGroup>
+    </PropertyGroup> -->
 
   </Target>
 
@@ -179,8 +199,8 @@
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>      
-        
+    </ConvertToAbsolutePath>
+
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseNewPack)"

--- a/HttpFs.UnitTests/HttpFs.UnitTests.fsproj
+++ b/HttpFs.UnitTests/HttpFs.UnitTests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Api.fs" />
     <Compile Include="RequestBody.fs" />
     <Compile Include="SendingStreams.fs" />
+    <Compile Include="SSE.fs" />
     <Compile Include="Program.fs" />
     <None Include="app.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/HttpFs.UnitTests/SSE.fs
+++ b/HttpFs.UnitTests/SSE.fs
@@ -1,0 +1,103 @@
+module HttpFs.Tests.SSE
+
+open Expecto
+open HttpFs.SSE
+
+let stockLines = [
+  "data: YHOO"
+  "data: +2"
+  "data: 10"
+  ""
+]
+
+let example2Lines = [
+  ": test stream"
+  ""
+  "data: first event"
+  "id: 1"
+  ""
+  "data:second event"
+  "id"
+  ""
+  "data:  third event"
+  ""
+]
+
+let example3Lines = [
+  "data"
+  ""
+  "data"
+  "data"
+  ""
+  "data:"
+]
+
+let example4Lines = [
+  "data:test"
+  ""
+  "data: test"
+  ""
+]
+
+[<Tests>]
+let interpretation =
+  testList "interpretation" [
+    testCase "stock" <| fun _ ->
+      let stockEvents =
+        stockLines
+        |> events
+        |> Seq.toArray
+      Expect.equal stockEvents.Length 1 "should result in 1 message"
+      Expect.equal stockEvents.[0].data "YHOO\n+2\n10" "should have correct data"
+      Expect.equal stockEvents.[0].lastEventId "" "should have correct event id"
+      Expect.equal stockEvents.[0].eventType "message" "should have correct event type"
+
+    testCase "example2" <| fun _ ->
+      let example2Events =
+        example2Lines
+        |> events
+        |> Seq.toArray
+      Expect.equal example2Events.Length 3 "should result in 3 messages"
+      Expect.equal example2Events.[0].data "first event" "should have correct data"
+      Expect.equal example2Events.[0].lastEventId "1" "should have correct event id"
+      Expect.equal example2Events.[0].eventType "message" "should have correct event type"
+      Expect.equal example2Events.[1].data "second event" "should have correct data"
+      Expect.equal example2Events.[1].lastEventId "" "should have correct event id"
+      Expect.equal example2Events.[0].eventType "message" "should have correct event type"
+      Expect.equal example2Events.[2].data " third event" "should have correct data"
+      Expect.equal example2Events.[2].lastEventId "" "should have correct event id"
+      Expect.equal example2Events.[0].eventType "message" "should have correct event type"
+
+    testCase "example3" <| fun _ ->
+      let example3Events =
+        example3Lines
+        |> events
+        |> Seq.toArray
+    // This is what the example decription says
+    //   Expect.equal example3Events.Length 2 "should result in 2 messages"
+    //   Expect.equal example3Events.[0].data "" "should have correct data"
+    //   Expect.equal example3Events.[0].lastEventId "" "should have correct event id"
+    //   Expect.equal example3Events.[0].eventType "message" "should have correct event type"
+    //   Expect.equal example3Events.[1].data "\n" "should have correct data"
+    //   Expect.equal example3Events.[1].lastEventId "" "should have correct event id"
+    //   Expect.equal example3Events.[0].eventType "message" "should have correct event type"
+    // But the specification says that empty events are not fired at all,
+    // so this is what we actually expect.
+      Expect.equal example3Events.Length 1 "should result in 1 messages"
+      Expect.equal example3Events.[0].data "\n" "should have correct data"
+      Expect.equal example3Events.[0].lastEventId "" "should have correct event id"
+      Expect.equal example3Events.[0].eventType "message" "should have correct event type"
+
+    testCase "example4" <| fun _ ->
+      let example4Events =
+        example4Lines
+        |> events
+        |> Seq.toArray
+      Expect.equal example4Events.Length 2 "should result in 2 messages"
+      Expect.equal example4Events.[0].data "test" "should have correct data"
+      Expect.equal example4Events.[0].lastEventId "" "should have correct event id"
+      Expect.equal example4Events.[0].eventType "message" "should have correct event type"
+      Expect.equal example4Events.[1].data "test" "should have correct data"
+      Expect.equal example4Events.[1].lastEventId "" "should have correct event id"
+      Expect.equal example4Events.[0].eventType "message" "should have correct event type"
+  ]

--- a/HttpFs.UnitTests/SSE.fs
+++ b/HttpFs.UnitTests/SSE.fs
@@ -3,101 +3,187 @@ module HttpFs.Tests.SSE
 open Expecto
 open HttpFs.SSE
 
-let stockLines = [
-  "data: YHOO"
-  "data: +2"
-  "data: 10"
-  ""
-]
+/// Taken from here: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events-intro
+module IntroductionExamples =
+  let example1Lines = [
+    "data: This is the first message."
+    ""
+    "data: This is the second message, it"
+    "data: has two lines."
+    ""
+    "data: This is the third message."
+    ""
+  ]
 
-let example2Lines = [
-  ": test stream"
-  ""
-  "data: first event"
-  "id: 1"
-  ""
-  "data:second event"
-  "id"
-  ""
-  "data:  third event"
-  ""
-]
+  let example2Lines = [
+    "event: add"
+    "data: 73857293"
+    ""
+    "event: remove"
+    "data: 2153"
+    ""
+    "event: add"
+    "data: 113411"
+    ""
+  ]
 
-let example3Lines = [
-  "data"
-  ""
-  "data"
-  "data"
-  ""
-  "data:"
-]
+/// Taken from here: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+module InterpretationExamples =
+    let example1Lines = [
+      "data: YHOO"
+      "data: +2"
+      "data: 10"
+      ""
+    ]
 
-let example4Lines = [
-  "data:test"
-  ""
-  "data: test"
-  ""
-]
+    let example2Lines = [
+      ": test stream"
+      ""
+      "data: first event"
+      "id: 1"
+      ""
+      "data:second event"
+      "id"
+      ""
+      "data:  third event"
+      ""
+    ]
+
+    let example3Lines = [
+      "data"
+      ""
+      "data"
+      "data"
+      ""
+      "data:"
+    ]
+
+    let example4Lines = [
+      "data:test"
+      ""
+      "data: test"
+      ""
+    ]
 
 [<Tests>]
 let interpretation =
   testList "interpretation" [
-    testCase "stock" <| fun _ ->
-      let stockEvents =
-        stockLines
-        |> events
-        |> Seq.toArray
-      Expect.equal stockEvents.Length 1 "should result in 1 message"
-      Expect.equal stockEvents.[0].data "YHOO\n+2\n10" "should have correct data"
-      Expect.equal stockEvents.[0].lastEventId "" "should have correct event id"
-      Expect.equal stockEvents.[0].eventType "message" "should have correct event type"
+    testList "examples" [
+      testList "introduction" [
+        testCase "example1" <| fun _ ->
+          let example1Events =
+            IntroductionExamples.example1Lines
+            |> events
+            |> Seq.toArray
 
-    testCase "example2" <| fun _ ->
-      let example2Events =
-        example2Lines
-        |> events
-        |> Seq.toArray
-      Expect.equal example2Events.Length 3 "should result in 3 messages"
-      Expect.equal example2Events.[0].data "first event" "should have correct data"
-      Expect.equal example2Events.[0].lastEventId "1" "should have correct event id"
-      Expect.equal example2Events.[0].eventType "message" "should have correct event type"
-      Expect.equal example2Events.[1].data "second event" "should have correct data"
-      Expect.equal example2Events.[1].lastEventId "" "should have correct event id"
-      Expect.equal example2Events.[0].eventType "message" "should have correct event type"
-      Expect.equal example2Events.[2].data " third event" "should have correct data"
-      Expect.equal example2Events.[2].lastEventId "" "should have correct event id"
-      Expect.equal example2Events.[0].eventType "message" "should have correct event type"
+          Expect.equal example1Events.Length 3 "should result in 3 message"
 
-    testCase "example3" <| fun _ ->
-      let example3Events =
-        example3Lines
-        |> events
-        |> Seq.toArray
-    // This is what the example decription says
-    //   Expect.equal example3Events.Length 2 "should result in 2 messages"
-    //   Expect.equal example3Events.[0].data "" "should have correct data"
-    //   Expect.equal example3Events.[0].lastEventId "" "should have correct event id"
-    //   Expect.equal example3Events.[0].eventType "message" "should have correct event type"
-    //   Expect.equal example3Events.[1].data "\n" "should have correct data"
-    //   Expect.equal example3Events.[1].lastEventId "" "should have correct event id"
-    //   Expect.equal example3Events.[0].eventType "message" "should have correct event type"
-    // But the specification says that empty events are not fired at all,
-    // so this is what we actually expect.
-      Expect.equal example3Events.Length 1 "should result in 1 messages"
-      Expect.equal example3Events.[0].data "\n" "should have correct data"
-      Expect.equal example3Events.[0].lastEventId "" "should have correct event id"
-      Expect.equal example3Events.[0].eventType "message" "should have correct event type"
+          Expect.equal example1Events.[0].data "This is the first message." "should have correct data"
+          Expect.equal example1Events.[0].lastEventId "" "should have correct event id"
+          Expect.equal example1Events.[0].eventType "message" "should have correct event type"
 
-    testCase "example4" <| fun _ ->
-      let example4Events =
-        example4Lines
-        |> events
-        |> Seq.toArray
-      Expect.equal example4Events.Length 2 "should result in 2 messages"
-      Expect.equal example4Events.[0].data "test" "should have correct data"
-      Expect.equal example4Events.[0].lastEventId "" "should have correct event id"
-      Expect.equal example4Events.[0].eventType "message" "should have correct event type"
-      Expect.equal example4Events.[1].data "test" "should have correct data"
-      Expect.equal example4Events.[1].lastEventId "" "should have correct event id"
-      Expect.equal example4Events.[0].eventType "message" "should have correct event type"
+          Expect.equal example1Events.[1].data "This is the second message, it\nhas two lines." "should have correct data"
+          Expect.equal example1Events.[1].lastEventId "" "should have correct event id"
+          Expect.equal example1Events.[1].eventType "message" "should have correct event type"
+
+          Expect.equal example1Events.[2].data "This is the third message." "should have correct data"
+          Expect.equal example1Events.[2].lastEventId "" "should have correct event id"
+          Expect.equal example1Events.[2].eventType "message" "should have correct event type"
+
+        testCase "example2" <| fun _ ->
+          let example2Events =
+            IntroductionExamples.example2Lines
+            |> events
+            |> Seq.toArray
+
+          Expect.equal example2Events.Length 3 "should result in 3 message"
+
+          Expect.equal example2Events.[0].data "73857293" "should have correct data"
+          Expect.equal example2Events.[0].lastEventId "" "should have correct event id"
+          Expect.equal example2Events.[0].eventType "add" "should have correct event type"
+
+          Expect.equal example2Events.[1].data "2153" "should have correct data"
+          Expect.equal example2Events.[1].lastEventId "" "should have correct event id"
+          Expect.equal example2Events.[1].eventType "remove" "should have correct event type"
+
+          Expect.equal example2Events.[2].data "113411" "should have correct data"
+          Expect.equal example2Events.[2].lastEventId "" "should have correct event id"
+          Expect.equal example2Events.[2].eventType "add" "should have correct event type"
+      ]
+
+      testList "interpretation" [
+        testCase "example1" <| fun _ ->
+          let example1Events =
+            InterpretationExamples.example1Lines
+            |> events
+            |> Seq.toArray
+
+          Expect.equal example1Events.Length 1 "should result in 1 message"
+
+          Expect.equal example1Events.[0].data "YHOO\n+2\n10" "should have correct data"
+          Expect.equal example1Events.[0].lastEventId "" "should have correct event id"
+          Expect.equal example1Events.[0].eventType "message" "should have correct event type"
+
+        testCase "example2" <| fun _ ->
+          let example2Events =
+            InterpretationExamples.example2Lines
+            |> events
+            |> Seq.toArray
+
+          Expect.equal example2Events.Length 3 "should result in 3 messages"
+
+          Expect.equal example2Events.[0].data "first event" "should have correct data"
+          Expect.equal example2Events.[0].lastEventId "1" "should have correct event id"
+          Expect.equal example2Events.[0].eventType "message" "should have correct event type"
+
+          Expect.equal example2Events.[1].data "second event" "should have correct data"
+          Expect.equal example2Events.[1].lastEventId "" "should have correct event id"
+          Expect.equal example2Events.[1].eventType "message" "should have correct event type"
+
+          Expect.equal example2Events.[2].data " third event" "should have correct data"
+          Expect.equal example2Events.[2].lastEventId "" "should have correct event id"
+          Expect.equal example2Events.[2].eventType "message" "should have correct event type"
+
+        testCase "example3" <| fun _ ->
+          let example3Events =
+            InterpretationExamples.example3Lines
+            |> events
+            |> Seq.toArray
+        // This is what the example decription says
+        //   Expect.equal example3Events.Length 2 "should result in 2 messages"
+        //
+        //   Expect.equal example3Events.[0].data "" "should have correct data"
+        //   Expect.equal example3Events.[0].lastEventId "" "should have correct event id"
+        //   Expect.equal example3Events.[0].eventType "message" "should have correct event type"
+        //
+        //   Expect.equal example3Events.[1].data "\n" "should have correct data"
+        //   Expect.equal example3Events.[1].lastEventId "" "should have correct event id"
+        //   Expect.equal example3Events.[1].eventType "message" "should have correct event type"
+        // 
+        // But the specification says that empty events are not fired at all,
+        // so this is what we actually expect.
+
+          Expect.equal example3Events.Length 1 "should result in 1 messages"
+
+          Expect.equal example3Events.[0].data "\n" "should have correct data"
+          Expect.equal example3Events.[0].lastEventId "" "should have correct event id"
+          Expect.equal example3Events.[0].eventType "message" "should have correct event type"
+
+        testCase "example4" <| fun _ ->
+          let example4Events =
+            InterpretationExamples.example4Lines
+            |> events
+            |> Seq.toArray
+
+          Expect.equal example4Events.Length 2 "should result in 2 messages"
+
+          Expect.equal example4Events.[0].data "test" "should have correct data"
+          Expect.equal example4Events.[0].lastEventId "" "should have correct event id"
+          Expect.equal example4Events.[0].eventType "message" "should have correct event type"
+
+          Expect.equal example4Events.[1].data "test" "should have correct data"
+          Expect.equal example4Events.[1].lastEventId "" "should have correct event id"
+          Expect.equal example4Events.[1].eventType "message" "should have correct event type"
+      ]
+    ]
   ]

--- a/HttpFs/HttpFs.fs
+++ b/HttpFs/HttpFs.fs
@@ -983,6 +983,16 @@ module Client =
     tryGetEventSourceResponse request
     |> Alt.afterFun getResponseOrFail
 
+  let getEventSource request =
+    getEventSourceResponse request
+    |> Alt.afterFun (fun resp ->
+      let streamer =
+        let charset = Encoding.UTF8
+        let sr = new System.IO.StreamReader(resp.body, charset)
+        Job.fromTask sr.ReadLineAsync
+      SSE.streamEvents streamer
+    )
+
   [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
   module Response =
     let readBodyAsString (response : Response) : Job<string> =

--- a/HttpFs/HttpFs.fsproj
+++ b/HttpFs/HttpFs.fsproj
@@ -16,6 +16,7 @@
       <Link>paket-files/Facade.fs</Link>
     </Compile>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="SSE.fs" />
     <Compile Include="HttpFs.fs" />
     <PackageReference Include="FSharp.Core" Version="4.1.18" />
   </ItemGroup>

--- a/HttpFs/SSE.fs
+++ b/HttpFs/SSE.fs
@@ -1,0 +1,149 @@
+namespace HttpFs
+
+/// See https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+module SSE =
+  open Hopac
+  open Hopac.Infixes
+
+  let (|EventComplete|Comment|Field|) (line: string) =
+    if line = "" then EventComplete else
+    match line.IndexOf ":" with
+    | 0 ->
+      Comment (line.Substring 1)
+    | n when n > 0 ->
+      let before = line.Substring(0,n)
+      let after = line.Substring(n+1)
+      let fieldValue =
+        if after.StartsWith " " then
+          after.Substring 1
+        else
+          after
+      Field (before, fieldValue)
+    | _ ->
+      Field (line, "")
+
+  let isASCIIDigit c =
+    System.Char.IsDigit c
+
+  let (|EventType|Data|EventId|Retry|Ignore|) (fieldName, fieldValue: string) =
+    match fieldName with
+    | "event" ->
+      EventType fieldValue
+
+    | "data" ->
+      Data fieldValue
+
+    | "id" ->
+      match fieldValue.IndexOf "\u0000" with
+      | n when n > 0 ->
+        Ignore
+      | _ ->
+        EventId fieldValue
+
+    | "retry" ->
+      if fieldValue.ToCharArray() |> Array.forall isASCIIDigit then
+          Retry (int fieldValue)
+      else
+        Ignore
+
+    | _ ->
+      Ignore
+  
+  type State = {
+    eventType: string
+    data: string list // stored in reverse order
+    lastEventId: string
+    reconnectionTime: int
+  }
+
+  let initialState = {
+    eventType = ""
+    data = []
+    lastEventId = ""
+    reconnectionTime = 0
+  }
+
+  let interpretField state =
+    function
+    | EventType et ->
+      { state with eventType = et }
+
+    | Data d ->
+      { state with data = d::state.data }
+
+    | EventId eid ->
+      { state with lastEventId = eid }
+
+    | Retry r ->
+      { state with reconnectionTime = r }
+
+    | Ignore ->
+      state
+
+  let reset (state: State) = {
+    eventType = ""
+    data = []
+    lastEventId = state.lastEventId
+    reconnectionTime = state.reconnectionTime
+  }
+
+  type Event = {
+    eventType: string
+    data: string
+    lastEventId: string
+  }
+
+  let dispatchEvent (state: State) =
+    let data =
+      state.data
+      |> List.rev
+      |> String.concat "\n"
+
+    if data = "" then
+      None
+    else
+      let data =
+        if data.EndsWith "\u+000A" then data.Substring (0, data.Length - 1) else data
+      let eventType =
+        if state.eventType = "" then "message" else state.eventType
+      Some
+        { eventType = eventType
+          data = data
+          lastEventId = state.lastEventId }
+
+  let interpret (state: State) =
+    function
+    | EventComplete ->
+      reset state, dispatchEvent state
+
+    | Comment _ ->
+      state, None
+
+    | Field (n,v) ->
+      interpretField state (n,v), None
+
+  let events lines =
+    let init =
+      initialState, None
+    Seq.scan (fun (s, _) l -> interpret s l) init lines
+    |> Seq.choose snd
+
+//   let streamer (resp: Response) =
+//     let charset = Encoding.UTF8
+//     let sr = new System.IO.StreamReader(resp.body, charset)
+//     Job.fromTask sr.ReadLineAsync
+  type Streamer = {
+    read: Job<Streamer * Event>
+  }
+
+  let streamEvents streamer =
+    let rec inner s =
+      streamer
+      >>- interpret s
+      >>= function (s, eo) ->
+            match eo with
+            | Some e ->
+              Job.result ( { read = inner s }, e)
+            | None ->
+              inner s
+    inner initialState

--- a/HttpFs/SSE.fs
+++ b/HttpFs/SSE.fs
@@ -128,10 +128,7 @@ module SSE =
     Seq.scan (fun (s, _) l -> interpret s l) init lines
     |> Seq.choose snd
 
-//   let streamer (resp: Response) =
-//     let charset = Encoding.UTF8
-//     let sr = new System.IO.StreamReader(resp.body, charset)
-//     Job.fromTask sr.ReadLineAsync
+  /// Stateful streaming
   type Streamer = {
     read: Job<Streamer * Event>
   }


### PR DESCRIPTION
There unit tests for the interpretation. These currently only consists of the examples from
https://html.spec.whatwg.org/multipage/server-sent-events.html, some should be written for the corner cases in the spec (like lines ending in LF). Also, the functions for reading from an actual response using jobs should be subject to the same tests.