### PR TITLE
Add custom HTTP methods support

### DIFF
--- a/HttpFs.IntegrationTests/HttpServer.fs
+++ b/HttpFs.IntegrationTests/HttpServer.fs
@@ -182,6 +182,8 @@ let app =
     Filters.PUT >=> Filters.path "/Put" >=> Successful.OK ""
 
     Filters.PATCH >=> Filters.path "/Patch" >=> Successful.OK ""
+
+    Filters.method (HttpMethod.OTHER "OTHER") >=> Filters.path "/Other" >=> Successful.OK ""
   ]
 
 type SuaveTestServer() =

--- a/HttpFs.IntegrationTests/Tests.fs
+++ b/HttpFs.IntegrationTests/Tests.fs
@@ -461,6 +461,15 @@ let tests =
       Expect.equal resp.statusCode 200 "statusCode should be equal"
     }
 
+    testCaseAsync "Other method works" <| async {
+        use! resp = 
+          Request.create (HttpMethod.Other "OTHER") (uriFor "/Other")
+          |> getResponse
+          |> Alt.toAsync
+    
+        Expect.equal resp.statusCode 200 "status code should be equal"
+    }
+
     testCaseAsync "getResponse.ResponseUri should contain URI that responded to the request" <| async {
       // Is going to redirect to another route and return GET 200.
       let request =


### PR DESCRIPTION
I've added a new option called ``Other`` to the ``RequestMethod`` union. Here is the issue: #161 

Originally I also wanted to pass some ``boolean`` to detect whether you want your method to support body or not, but after looking at other web-request related APIs I haven't seen anyone doing that, so I only left one string parameter representing a verb itself.

For some reason Pack target failed for me (similarly to #164 ). Updating Paket didn't work (or I've done something wrong).

One of the edge cases I didn't handled is when user tries to pass "GET" as a custom header and this will allow him to set a body for his request. Not sure you need to handle that, so for now it's just FYI.

Also in order to support new union member with parameter, I had to adjust the logic of determining whether request should include body depending on method (used pattern matching instead of equality check).